### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
       - name: GitHub Actions Version Updater bullseye
-        uses: rbroderi/github-actions-version-updater@Release2
+        uses: rbroderi/github-actions-version-updater@Release3
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[rbroderi/github-actions-version-updater](https://github.com/rbroderi/github-actions-version-updater)** published a new release **[Release3](https://github.com/rbroderi/github-actions-version-updater/releases/tag/Release3)** on 2025-07-13T05:24:50Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
