### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0 # Fetch all history for git info
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 18.14
       - name: Install Dependencies
@@ -29,7 +29,7 @@ jobs:
       - name: Build Quartz
         run: npx quartz build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: public
  

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)** on 2025-08-14T19:21:06Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0)** on 2026-03-04T02:52:09Z
