### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0 # Fetch all history for git info
-      - uses: actions/setup-node@v6.3.0
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 18.14
       - name: Install Dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.4.0](https://github.com/actions/setup-node/releases/tag/v6.4.0)** on 2026-04-20T02:57:28Z
